### PR TITLE
sync with latest changes from CVS

### DIFF
--- a/man/imsg_init.3
+++ b/man/imsg_init.3
@@ -1,4 +1,4 @@
-.\" $OpenBSD: imsg_init.3,v 1.23 2019/01/20 02:50:03 bcook Exp $
+.\" $OpenBSD: imsg_init.3,v 1.28 2023/06/20 06:53:29 jsg Exp $
 .\"
 .\" Copyright (c) 2010 Nicholas Marriott <nicm@openbsd.org>
 .\"
@@ -14,7 +14,7 @@
 .\" IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
 .\" OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 .\"
-.Dd $Mdocdate: January 20 2019 $
+.Dd $Mdocdate: June 20 2023 $
 .Dt IMSG_INIT 3
 .Os
 .Sh NAME
@@ -23,6 +23,7 @@
 .Nm imsg_get ,
 .Nm imsg_compose ,
 .Nm imsg_composev ,
+.Nm imsg_compose_ibuf ,
 .Nm imsg_create ,
 .Nm imsg_add ,
 .Nm imsg_close ,
@@ -32,17 +33,31 @@
 .Nm ibuf_open ,
 .Nm ibuf_dynamic ,
 .Nm ibuf_add ,
+.Nm ibuf_add_buf ,
+.Nm ibuf_add_n8 ,
+.Nm ibuf_add_n16 ,
+.Nm ibuf_add_n32 ,
+.Nm ibuf_add_n64 ,
+.Nm ibuf_add_zero ,
 .Nm ibuf_reserve ,
 .Nm ibuf_seek ,
+.Nm ibuf_set ,
+.Nm ibuf_set_n8 ,
+.Nm ibuf_set_n16 ,
+.Nm ibuf_set_n32 ,
+.Nm ibuf_set_n64 ,
+.Nm ibuf_data ,
 .Nm ibuf_size ,
 .Nm ibuf_left ,
 .Nm ibuf_close ,
-.Nm ibuf_write ,
 .Nm ibuf_free ,
+.Nm ibuf_fd_avail ,
+.Nm ibuf_fd_get ,
+.Nm ibuf_fd_set ,
+.Nm ibuf_write ,
 .Nm msgbuf_init ,
 .Nm msgbuf_clear ,
-.Nm msgbuf_write ,
-.Nm msgbuf_drain
+.Nm msgbuf_write
 .Nd IPC messaging functions
 .Sh SYNOPSIS
 .In sys/types.h
@@ -62,6 +77,9 @@
 .Ft int
 .Fn imsg_composev "struct imsgbuf *ibuf" "uint32_t type" "uint32_t peerid" \
     "pid_t pid" "int fd" "const struct iovec *iov" "int iovcnt"
+.Ft int
+.Fn imsg_compose_ibuf "struct imsgbuf *ibuf" "uint32_t type" "uint32_t peerid" \
+    "pid_t pid" "struct ibuf *buf"
 .Ft "struct ibuf *"
 .Fn imsg_create "struct imsgbuf *ibuf" "uint32_t type" "uint32_t peerid" \
     "pid_t pid" "uint16_t datalen"
@@ -81,28 +99,57 @@
 .Fn ibuf_dynamic "size_t len" "size_t max"
 .Ft int
 .Fn ibuf_add "struct ibuf *buf" "const void *data" "size_t len"
+.Ft int
+.Fn ibuf_add_buf "struct ibuf *buf" "const struct ibuf *from"
+.Ft int
+.Fn ibuf_add_n8 "struct ibuf *buf" "uint64_t value"
+.Ft int
+.Fn ibuf_add_n16 "struct ibuf *buf" "uint64_t value"
+.Ft int
+.Fn ibuf_add_n32 "struct ibuf *buf" "uint64_t value"
+.Ft int
+.Fn ibuf_add_n64 "struct ibuf *buf" "uint64_t value"
+.Ft int
+.Fn ibuf_add_zero "struct ibuf *buf" "size_t len"
 .Ft "void *"
 .Fn ibuf_reserve "struct ibuf *buf" "size_t len"
 .Ft "void *"
 .Fn ibuf_seek "struct ibuf *buf" "size_t pos" "size_t len"
+.Ft int
+.Fn ibuf_set "struct ibuf *buf" "size_t pos" "const void *data" \
+    "size_t len"
+.Ft int
+.Fn ibuf_set_n8 "struct ibuf *buf" "size_t pos" "uint64_t value"
+.Ft int
+.Fn ibuf_set_n16 "struct ibuf *buf" "size_t pos" "uint64_t value"
+.Ft int
+.Fn ibuf_set_n32 "struct ibuf *buf" "size_t pos" "uint64_t value"
+.Ft int
+.Fn ibuf_set_n64 "struct ibuf *buf" "size_t pos" "uint64_t value"
+.Ft "void *"
+.Fn ibuf_data "struct ibuf *buf"
 .Ft size_t
 .Fn ibuf_size "struct ibuf *buf"
 .Ft size_t
 .Fn ibuf_left "struct ibuf *buf"
 .Ft void
 .Fn ibuf_close "struct msgbuf *msgbuf" "struct ibuf *buf"
-.Ft int
-.Fn ibuf_write "struct msgbuf *msgbuf"
 .Ft void
 .Fn ibuf_free "struct ibuf *buf"
+.Ft int
+.Fn ibuf_fd_avail "struct ibuf *buf"
+.Ft int
+.Fn ibuf_fd_get "struct ibuf *buf"
+.Ft void
+.Fn ibuf_fd_set "struct ibuf *buf" "int fd"
+.Ft int
+.Fn ibuf_write "struct msgbuf *msgbuf"
 .Ft void
 .Fn msgbuf_init "struct msgbuf *msgbuf"
 .Ft void
 .Fn msgbuf_clear "struct msgbuf *msgbuf"
 .Ft int
 .Fn msgbuf_write "struct msgbuf *msgbuf"
-.Ft void
-.Fn msgbuf_drain "struct msgbuf *msgbuf" "size_t n"
 .Sh DESCRIPTION
 The
 .Nm imsg
@@ -133,7 +180,7 @@ struct imsgbuf {
 .Ed
 .Pp
 .Fn imsg_init
-is a routine which initializes
+initializes
 .Fa ibuf
 as one side of a channel associated with
 .Fa fd .
@@ -187,7 +234,9 @@ bytes of ancillary data pointed to by
 .Fa data .
 It returns
 .Fa datalen
-if it succeeds, \-1 otherwise.
+if it succeeds, otherwise
+.Fa msg
+is freed and \-1 is returned.
 .Pp
 .Fn imsg_close
 completes creation of
@@ -197,7 +246,7 @@ by adding it to
 output buffer.
 .Pp
 .Fn imsg_compose
-is a routine which is used to quickly create and queue an imsg.
+is used to quickly create and queue an imsg.
 It takes the same parameters as the
 .Fn imsg_create ,
 .Fn imsg_add
@@ -221,8 +270,19 @@ It takes the same parameters, except that the ancillary data buffer is specified
 by
 .Fa iovec .
 .Pp
+.Fn imsg_compose_ibuf
+is similar to
+.Fn imsg_compose .
+It takes the same parameters, except that the ancillary data buffer is specified
+by an ibuf
+.Fa buf .
+This routine returns 1 if it succeeds, \-1 otherwise.
+In either case the buffer
+.Fa buf
+is consumed by the function.
+.Pp
 .Fn imsg_flush
-is a function which calls
+calls
 .Fn msgbuf_write
 in a loop until all imsgs in the output buffer are sent.
 It returns 0 if it succeeds, \-1 otherwise.
@@ -355,7 +415,34 @@ Buffers allocated with
 are automatically grown if necessary when data is added.
 .Pp
 .Fn ibuf_add
-is a routine which appends a block of data to
+appends a block of data to
+.Fa buf .
+0 is returned on success and \-1 on failure.
+.Pp
+.Fn ibuf_add_buf
+appends the buffer
+.Fa from
+to
+.Fa buf .
+0 is returned on success and \-1 on failure.
+.Pp
+.Fn ibuf_add_n8 ,
+.Fn ibuf_add_n16 ,
+.Fn ibuf_add_n32 ,
+and
+.Fn ibuf_add_n64
+add a 1-byte, 2-byte, 4-byte, and 8-byte
+.Fa value
+to
+.Fa buf
+in network byte order.
+This function checks
+.Fa value
+to not overflow.
+0 is returned on success and \-1 on failure.
+.Pp
+.Fn ibuf_add_zero
+appends a block of zeros to
 .Fa buf .
 0 is returned on success and \-1 on failure.
 .Pp
@@ -367,12 +454,44 @@ bytes in
 A pointer to the start of the reserved space is returned, or NULL on error.
 .Pp
 .Fn ibuf_seek
-is a function which returns a pointer to the part of the buffer at offset
+returns a pointer to the part of the buffer at offset
 .Fa pos
 and of extent
 .Fa len .
 NULL is returned if the requested range is outside the part of the buffer
 in use.
+.Pp
+.Fn ibuf_set
+replaces a part of
+.Fa buf
+at offset
+.Fa pos
+with the data of extent
+.Fa len .
+0 is returned on success and \-1 on failure.
+.Pp
+.Fn ibuf_set_n8 ,
+.Fn ibuf_set_n16 ,
+.Fn ibuf_seek_set_n32
+and
+.Fn ibuf_seek_set_n64
+replace a 1-byte, 2-byte, 4-byte or 8-byte
+.Fa value
+at offset
+.Fa pos
+in the buffer
+.Fa buf
+in network byte order.
+This function checks
+.Fa value
+to not overflow.
+0 is returned on success and \-1 on failure.
+.Pp
+.Fn ibuf_data
+returns the pointer to the internal buffer.
+This function should only be used together with
+.Fn ibuf_size
+to process a previously generated buffer.
 .Pp
 .Fn ibuf_size
 and
@@ -388,6 +507,35 @@ to
 .Fa msgbuf
 ready to be sent.
 .Pp
+.Fn ibuf_fd_avail ,
+.Fn ibuf_fd_get
+and
+.Fn ibuf_fd_set
+are functions to check, get and set the file descriptor assigned to
+.Fa buf .
+After calling
+.Fn ibuf_fd_set
+the file descriptor is part of the
+.Fa buf
+and will be transmitted or closed by the ibuf API.
+Any previously set file descriptor will be closed before assigning a
+new descriptor.
+.Fn ibuf_fd_get
+returns the file descriptor and passes the responsibility to track the
+descriptor back to the program.
+.Fn ibuf_fd_avail
+returns true if there is a file descriptor set on
+.Fa buf .
+.Pp
+.Fn ibuf_free
+frees
+.Fa buf
+and any associated storage, and closes any file descriptor set with
+.Fn ibuf_fd_set .
+If
+.Fa buf
+is a NULL pointer, no action occurs.
+.Pp
 The
 .Fn ibuf_write
 routine transmits as many pending buffers as possible from
@@ -399,14 +547,6 @@ pending or an EOF condition on the socket is detected.
 Temporary resource shortages are returned with errno
 .Er EAGAIN
 and require the application to retry again in the future.
-.Pp
-.Fn ibuf_free
-frees
-.Fa buf
-and any associated storage.
-If
-.Fa buf
-is a NULL pointer, no action occurs.
 .Pp
 The
 .Fn msgbuf_init
@@ -433,15 +573,6 @@ or an EOF condition on the socket is detected.
 Temporary resource shortages are returned with errno
 .Er EAGAIN
 and require the application to retry again in the future.
-.Pp
-.Fn msgbuf_drain
-discards data from buffers queued in
-.Fa msgbuf
-until
-.Fa n
-bytes have been removed or
-.Fa msgbuf
-is empty.
 .Sh EXAMPLES
 In a typical program, a channel between two processes is created with
 .Xr socketpair 2 ,

--- a/src/imsg-buffer.c
+++ b/src/imsg-buffer.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: imsg-buffer.c,v 1.13 2021/03/31 17:42:24 eric Exp $	*/
+/*	$OpenBSD: imsg-buffer.c,v 1.16 2023/06/19 17:19:50 claudio Exp $	*/
 
 /*
  * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
@@ -23,6 +23,7 @@
 
 #include <limits.h>
 #include <errno.h>
+#include <endian.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -33,15 +34,20 @@
 static int	ibuf_realloc(struct ibuf *, size_t);
 static void	ibuf_enqueue(struct msgbuf *, struct ibuf *);
 static void	ibuf_dequeue(struct msgbuf *, struct ibuf *);
+static void	msgbuf_drain(struct msgbuf *, size_t);
 
 struct ibuf *
 ibuf_open(size_t len)
 {
 	struct ibuf	*buf;
 
+	if (len == 0) {
+		errno = EINVAL;
+		return (NULL);
+	}
 	if ((buf = calloc(1, sizeof(struct ibuf))) == NULL)
 		return (NULL);
-	if ((buf->buf = malloc(len)) == NULL) {
+	if ((buf->buf = calloc(len, 1)) == NULL) {
 		free(buf);
 		return (NULL);
 	}
@@ -56,14 +62,22 @@ ibuf_dynamic(size_t len, size_t max)
 {
 	struct ibuf	*buf;
 
-	if (max < len)
+	if (max < len) {
+		errno = EINVAL;
 		return (NULL);
+	}
 
-	if ((buf = ibuf_open(len)) == NULL)
+	if ((buf = calloc(1, sizeof(struct ibuf))) == NULL)
 		return (NULL);
-
-	if (max > 0)
-		buf->max = max;
+	if (len > 0) {
+		if ((buf->buf = calloc(len, 1)) == NULL) {
+			free(buf);
+			return (NULL);
+		}
+	}
+	buf->size = len;
+	buf->max = max;
+	buf->fd = -1;
 
 	return (buf);
 }
@@ -74,7 +88,7 @@ ibuf_realloc(struct ibuf *buf, size_t len)
 	unsigned char	*b;
 
 	/* on static buffers max is eq size and so the following fails */
-	if (buf->wpos + len > buf->max) {
+	if (len > SIZE_MAX - buf->wpos || buf->wpos + len > buf->max) {
 		errno = ERANGE;
 		return (-1);
 	}
@@ -88,22 +102,15 @@ ibuf_realloc(struct ibuf *buf, size_t len)
 	return (0);
 }
 
-int
-ibuf_add(struct ibuf *buf, const void *data, size_t len)
-{
-	if (buf->wpos + len > buf->size)
-		if (ibuf_realloc(buf, len) == -1)
-			return (-1);
-
-	memcpy(buf->buf + buf->wpos, data, len);
-	buf->wpos += len;
-	return (0);
-}
-
 void *
 ibuf_reserve(struct ibuf *buf, size_t len)
 {
 	void	*b;
+
+	if (len > SIZE_MAX - buf->wpos) {
+		errno = ERANGE;
+		return (NULL);
+	}
 
 	if (buf->wpos + len > buf->size)
 		if (ibuf_realloc(buf, len) == -1)
@@ -111,17 +118,158 @@ ibuf_reserve(struct ibuf *buf, size_t len)
 
 	b = buf->buf + buf->wpos;
 	buf->wpos += len;
+	memset(b, 0, len);
 	return (b);
+}
+
+int
+ibuf_add(struct ibuf *buf, const void *data, size_t len)
+{
+	void *b;
+
+	if ((b = ibuf_reserve(buf, len)) == NULL)
+		return (-1);
+
+	memcpy(b, data, len);
+	return (0);
+}
+
+int
+ibuf_add_buf(struct ibuf *buf, const struct ibuf *from)
+{
+	return ibuf_add(buf, from->buf, from->wpos);
+}
+
+int
+ibuf_add_n8(struct ibuf *buf, uint64_t value)
+{
+	uint8_t v;
+
+	if (value > UINT8_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = value;
+	return ibuf_add(buf, &v, sizeof(v));
+}
+
+int
+ibuf_add_n16(struct ibuf *buf, uint64_t value)
+{
+	uint16_t v;
+
+	if (value > UINT16_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = htobe16(value);
+	return ibuf_add(buf, &v, sizeof(v));
+}
+
+int
+ibuf_add_n32(struct ibuf *buf, uint64_t value)
+{
+	uint32_t v;
+
+	if (value > UINT32_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = htobe32(value);
+	return ibuf_add(buf, &v, sizeof(v));
+}
+
+int
+ibuf_add_n64(struct ibuf *buf, uint64_t value)
+{
+	value = htobe64(value);
+	return ibuf_add(buf, &value, sizeof(value));
+}
+
+int
+ibuf_add_zero(struct ibuf *buf, size_t len)
+{
+	void *b;
+
+	if ((b = ibuf_reserve(buf, len)) == NULL)
+		return (-1);
+	return (0);
 }
 
 void *
 ibuf_seek(struct ibuf *buf, size_t pos, size_t len)
 {
 	/* only allowed to seek in already written parts */
-	if (pos + len > buf->wpos)
+	if (len > SIZE_MAX - pos || pos + len > buf->wpos) {
+		errno = ERANGE;
 		return (NULL);
+	}
 
 	return (buf->buf + pos);
+}
+
+int
+ibuf_set(struct ibuf *buf, size_t pos, const void *data, size_t len)
+{
+	void *b;
+
+	if ((b = ibuf_seek(buf, pos, len)) == NULL)
+		return (-1);
+
+	memcpy(b, data, len);
+	return (0);
+}
+
+int
+ibuf_set_n8(struct ibuf *buf, size_t pos, uint64_t value)
+{
+	uint8_t v;
+
+	if (value > UINT8_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = value;
+	return (ibuf_set(buf, pos, &v, sizeof(v)));
+}
+
+int
+ibuf_set_n16(struct ibuf *buf, size_t pos, uint64_t value)
+{
+	uint16_t v;
+
+	if (value > UINT16_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = htobe16(value);
+	return (ibuf_set(buf, pos, &v, sizeof(v)));
+}
+
+int
+ibuf_set_n32(struct ibuf *buf, size_t pos, uint64_t value)
+{
+	uint32_t v;
+
+	if (value > UINT32_MAX) {
+		errno = EINVAL;
+		return (-1);
+	}
+	v = htobe32(value);
+	return (ibuf_set(buf, pos, &v, sizeof(v)));
+}
+
+int
+ibuf_set_n64(struct ibuf *buf, size_t pos, uint64_t value)
+{
+	value = htobe64(value);
+	return (ibuf_set(buf, pos, &value, sizeof(value)));
+}
+
+void *
+ibuf_data(struct ibuf *buf)
+{
+	return (buf->buf);
 }
 
 size_t
@@ -140,6 +288,45 @@ void
 ibuf_close(struct msgbuf *msgbuf, struct ibuf *buf)
 {
 	ibuf_enqueue(msgbuf, buf);
+}
+
+void
+ibuf_free(struct ibuf *buf)
+{
+	if (buf == NULL)
+		return;
+#ifdef NOTYET
+	if (buf->fd != -1)
+		close(buf->fd);
+#endif
+	freezero(buf->buf, buf->size);
+	free(buf);
+}
+
+int
+ibuf_fd_avail(struct ibuf *buf)
+{
+	return (buf->fd != -1);
+}
+
+int
+ibuf_fd_get(struct ibuf *buf)
+{
+	int fd;
+
+	fd = buf->fd;
+#ifdef NOTYET
+	buf->fd = -1;
+#endif
+	return (fd);
+}
+
+void
+ibuf_fd_set(struct ibuf *buf, int fd)
+{
+	if (buf->fd != -1)
+		close(buf->fd);
+	buf->fd = fd;
 }
 
 int
@@ -179,15 +366,6 @@ again:
 }
 
 void
-ibuf_free(struct ibuf *buf)
-{
-	if (buf == NULL)
-		return;
-	freezero(buf->buf, buf->size);
-	free(buf);
-}
-
-void
 msgbuf_init(struct msgbuf *msgbuf)
 {
 	msgbuf->queued = 0;
@@ -195,7 +373,7 @@ msgbuf_init(struct msgbuf *msgbuf)
 	TAILQ_INIT(&msgbuf->bufs);
 }
 
-void
+static void
 msgbuf_drain(struct msgbuf *msgbuf, size_t n)
 {
 	struct ibuf	*buf, *next;
@@ -203,7 +381,7 @@ msgbuf_drain(struct msgbuf *msgbuf, size_t n)
 	for (buf = TAILQ_FIRST(&msgbuf->bufs); buf != NULL && n > 0;
 	    buf = next) {
 		next = TAILQ_NEXT(buf, entry);
-		if (buf->rpos + n >= buf->wpos) {
+		if (n >= buf->wpos - buf->rpos) {
 			n -= buf->wpos - buf->rpos;
 			ibuf_dequeue(msgbuf, buf);
 		} else {
@@ -304,8 +482,10 @@ ibuf_dequeue(struct msgbuf *msgbuf, struct ibuf *buf)
 {
 	TAILQ_REMOVE(&msgbuf->bufs, buf, entry);
 
-	if (buf->fd != -1)
+	if (buf->fd != -1) {
 		close(buf->fd);
+		buf->fd = -1;
+	}
 
 	msgbuf->queued--;
 	ibuf_free(buf);

--- a/src/imsg.c
+++ b/src/imsg.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: imsg.c,v 1.16 2017/12/14 09:27:44 kettenis Exp $	*/
+/*	$OpenBSD: imsg.c,v 1.19 2023/06/19 17:19:50 claudio Exp $	*/
 
 /*
  * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
@@ -151,7 +151,8 @@ imsg_get(struct imsgbuf *ibuf, struct imsg *imsg)
 	else
 		imsg->fd = -1;
 
-	memcpy(imsg->data, ibuf->r.rptr, datalen);
+	if (datalen != 0)
+		memcpy(imsg->data, ibuf->r.rptr, datalen);
 
 	if (imsg->hdr.len < av) {
 		left = av - imsg->hdr.len;
@@ -175,8 +176,7 @@ imsg_compose(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid, pid_t pid,
 	if (imsg_add(wbuf, data, datalen) == -1)
 		return (-1);
 
-	wbuf->fd = fd;
-
+	ibuf_fd_set(wbuf, fd);
 	imsg_close(ibuf, wbuf);
 
 	return (1);
@@ -199,14 +199,49 @@ imsg_composev(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid, pid_t pid,
 		if (imsg_add(wbuf, iov[i].iov_base, iov[i].iov_len) == -1)
 			return (-1);
 
-	wbuf->fd = fd;
-
+	ibuf_fd_set(wbuf, fd);
 	imsg_close(ibuf, wbuf);
 
 	return (1);
 }
 
-/* ARGSUSED */
+int
+imsg_compose_ibuf(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid,
+    pid_t pid, struct ibuf *buf)
+{
+	struct ibuf	*wbuf = NULL;
+	struct imsg_hdr	 hdr;
+	int save_errno;
+
+	if (ibuf_size(buf) + IMSG_HEADER_SIZE > MAX_IMSGSIZE) {
+		errno = ERANGE;
+		goto fail;
+	}
+
+	hdr.type = type;
+	hdr.len = ibuf_size(buf) + IMSG_HEADER_SIZE;
+	hdr.flags = 0;
+	hdr.peerid = peerid;
+	if ((hdr.pid = pid) == 0)
+		hdr.pid = ibuf->pid;
+
+	if ((wbuf = ibuf_open(IMSG_HEADER_SIZE)) == NULL)
+		goto fail;
+	if (imsg_add(wbuf, &hdr, sizeof(hdr)) == -1)
+		goto fail;
+
+	ibuf_close(&ibuf->w, wbuf);
+	ibuf_close(&ibuf->w, buf);
+	return (1);
+
+ fail:
+	save_errno = errno;
+	ibuf_free(buf);
+	ibuf_free(wbuf);
+	errno = save_errno;
+	return (-1);
+}
+
 struct ibuf *
 imsg_create(struct imsgbuf *ibuf, uint32_t type, uint32_t peerid, pid_t pid,
     uint16_t datalen)
@@ -253,10 +288,9 @@ imsg_close(struct imsgbuf *ibuf, struct ibuf *msg)
 	hdr = (struct imsg_hdr *)msg->buf;
 
 	hdr->flags &= ~IMSGF_HASFD;
-	if (msg->fd != -1)
+	if (ibuf_fd_avail(msg))
 		hdr->flags |= IMSGF_HASFD;
-
-	hdr->len = (uint16_t)msg->wpos;
+	hdr->len = ibuf_size(msg);
 
 	ibuf_close(&ibuf->w, msg);
 }

--- a/src/imsg.h
+++ b/src/imsg.h
@@ -1,4 +1,4 @@
-/*	$OpenBSD: imsg.h,v 1.6 2021/01/13 09:56:28 claudio Exp $	*/
+/*	$OpenBSD: imsg.h,v 1.7 2023/06/19 17:19:50 claudio Exp $	*/
 
 /*
  * Copyright (c) 2006, 2007 Pierre-Yves Ritschard <pyr@openbsd.org>
@@ -80,21 +80,35 @@ struct imsg {
 
 struct iovec;
 
-/* buffer.c */
+/* imsg-buffer.c */
 struct ibuf	*ibuf_open(size_t);
 struct ibuf	*ibuf_dynamic(size_t, size_t);
 int		 ibuf_add(struct ibuf *, const void *, size_t);
+int		 ibuf_add_buf(struct ibuf *, const struct ibuf *);
+int		 ibuf_add_zero(struct ibuf *, size_t);
+int		 ibuf_add_n8(struct ibuf *, uint64_t);
+int		 ibuf_add_n16(struct ibuf *, uint64_t);
+int		 ibuf_add_n32(struct ibuf *, uint64_t);
+int		 ibuf_add_n64(struct ibuf *, uint64_t);
 void		*ibuf_reserve(struct ibuf *, size_t);
 void		*ibuf_seek(struct ibuf *, size_t, size_t);
+int		 ibuf_set(struct ibuf *, size_t, const void *, size_t);
+int		 ibuf_set_n8(struct ibuf *, size_t, uint64_t);
+int		 ibuf_set_n16(struct ibuf *, size_t, uint64_t);
+int		 ibuf_set_n32(struct ibuf *, size_t, uint64_t);
+int		 ibuf_set_n64(struct ibuf *, size_t, uint64_t);
+void		*ibuf_data(struct ibuf *);
 size_t		 ibuf_size(struct ibuf *);
 size_t		 ibuf_left(struct ibuf *);
 void		 ibuf_close(struct msgbuf *, struct ibuf *);
-int		 ibuf_write(struct msgbuf *);
 void		 ibuf_free(struct ibuf *);
+int		 ibuf_fd_avail(struct ibuf *);
+int		 ibuf_fd_get(struct ibuf *);
+void		 ibuf_fd_set(struct ibuf *, int);
+int		 ibuf_write(struct msgbuf *);
 void		 msgbuf_init(struct msgbuf *);
 void		 msgbuf_clear(struct msgbuf *);
 int		 msgbuf_write(struct msgbuf *);
-void		 msgbuf_drain(struct msgbuf *, size_t);
 
 /* imsg.c */
 void	 imsg_init(struct imsgbuf *, int);
@@ -104,6 +118,8 @@ int	 imsg_compose(struct imsgbuf *, uint32_t, uint32_t, pid_t, int,
 	    const void *, uint16_t);
 int	 imsg_composev(struct imsgbuf *, uint32_t, uint32_t,  pid_t, int,
 	    const struct iovec *, int);
+int	 imsg_compose_ibuf(struct imsgbuf *, uint32_t, uint32_t, pid_t,
+	    struct ibuf *);
 struct ibuf *imsg_create(struct imsgbuf *, uint32_t, uint32_t, pid_t, uint16_t);
 int	 imsg_add(struct ibuf *, const void *, uint16_t);
 void	 imsg_close(struct imsgbuf *, struct ibuf *);


### PR DESCRIPTION
brings this back in sync with CVS.  After the last change by claudio@ `imsg-buffer.c` now needs `endian.h` too which is not practically portable yet: OpenBSD and linux have `endian.h`, FreeBSD and NetBSD `sys/endian.h` (but also OpenBSD for compatibility I guess), and then macos has its weird stuff in `libkern/OSByteOrder.h`.  

There's no configure script so I'm not sure how to tackle this.  using a `#ifdef __FreeBSD__` for instance should work, but it's ugly and a configure would avoid such hardcodings.