### PR TITLE
don't use unneeded make extensions; POSIX make is enough

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-VERSION ?=      6.8.2
+VERSION =       6.8.2
 
-STATICLIB ?=    libimsg.a
-SONAME ?=       libimsg.so
-LIBRARY ?=      libimsg.so.${VERSION}
+STATICLIB =     libimsg.a
+SONAME =        libimsg.so
+LIBRARY =       libimsg.so.${VERSION}
 
-DESTDIR ?=
-PREFIX ?=       /usr
-INCLUDEDIR ?=   ${PREFIX}/include
-LIBDIR ?=       ${PREFIX}/lib
-MANDIR ?=       ${PREFIX}/share/man
+DESTDIR =
+PREFIX =        /usr
+INCLUDEDIR =    ${PREFIX}/include
+LIBDIR =        ${PREFIX}/lib
+MANDIR =        ${PREFIX}/share/man
 
 SRCS =          src/imsg.c src/imsg-buffer.c
 OBJS =          ${SRCS:.c=.o}


### PR DESCRIPTION
There's no much need in setting once variables as `FOO ?= default-value` in make, since all the variables can be overridden from the command line `make FOO=bar` and/or `make -e`.

this makes the Makefile POSIX-compliant AFAIK.