### PR TITLE
use ${TESTSRCS} instead of $^

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ check: test
 test: all ${TESTOBJS}
 
 ${TESTOBJS}: ${TESTSRCS}
-	${CC} ${CFLAGS} -Isrc ${TESTSRCS} -o $@ -L. -limsg
-	env -i LD_LIBRARY_PATH=. ./$@
+	${CC} ${CFLAGS} -Isrc ${TESTSRCS} ${STATICLIB} -o $@
+	./$@
 
 clean:
 	rm -f ${LIBRARY} ${STATICLIB} ${OBJS} ${TESTOBJS} libimsg.pc

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check: test
 test: all ${TESTOBJS}
 
 ${TESTOBJS}: ${TESTSRCS}
-	${CC} ${CFLAGS} -Isrc $< -o $@ -L. -limsg
+	${CC} ${CFLAGS} -Isrc ${TESTSRCS} -o $@ -L. -limsg
 	env -i LD_LIBRARY_PATH=. ./$@
 
 clean:


### PR DESCRIPTION
OpenBSD make complains that "Using $< in a non-suffix rule context is a GNUmake idiom".

While here, use the static library to avoid using `LD_LIBRARY_PATH`.