### PR TITLE
Ease use of imsg-compat as meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,14 @@ sources = [
 ]
 
 libimsg = both_libraries('imsg', sources: sources, include_directories: incdir, install: true)
+
+libimsg_dep = declare_dependency(
+	include_directories: include_directories(incdir),
+	link_with: libimsg
+)
+meson.override_dependency('imsg', libimsg_dep)
+meson.override_dependency('libimsg', libimsg_dep)
+
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(libimsg, version: meson.project_version(), name: 'libimsg', description: 'Unofficial OpenBSD imsg port', libraries: libimsg)
 

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,8 @@ project('imsg-compat', 'c',
 	license: 'ISC',
 	default_options: [
 		'warning_level=3',
-	]
+	],
+	meson_version: '>=1.1.0'
 )
 
 compiler = meson.get_compiler('c')
@@ -83,7 +84,7 @@ libimsg = both_libraries('imsg', sources: sources, include_directories: incdir, 
 
 libimsg_dep = declare_dependency(
 	include_directories: include_directories(incdir),
-	link_with: libimsg
+	objects: libimsg.get_static_lib().extract_all_objects(recursive: true)
 )
 meson.override_dependency('imsg', libimsg_dep)
 meson.override_dependency('libimsg', libimsg_dep)


### PR DESCRIPTION
With this patch applied, meson enjoyers are able to just add `subprojects/imsg-compat.wrap` to their projects for meson to be able to fallback to a local build instead of searching for a system install of imsg-compat:

```
[wrap-file]
directory = imsg-compat-8.0.0

source_url = https://github.com/bsd-ac/imsg-compat/archive/refs/tags/8.0.0.tar.gz
source_filename = 8.0.0.tar.gz
surce_hash = ...
```

Afterwards, submitting to [WrapDB](https://mesonbuild.com/Adding-new-projects-to-wrapdb.html) might be an option.

Related documentation:
- https://mesonbuild.com/Reference-manual_builtin_meson.html#mesonoverride_dependency
- https://mesonbuild.com/Reference-manual_functions.html#declare_dependency
- https://mesonbuild.com/Wrap-dependency-system-manual.html#wrap-dependency-system-manual